### PR TITLE
Fix resize border blocking interactions when maximized

### DIFF
--- a/windows/bitsdojo_window.cpp
+++ b/windows/bitsdojo_window.cpp
@@ -144,6 +144,9 @@ void extendIntoClientArea(HWND hwnd)
 
 LRESULT handle_nchittest(HWND window, WPARAM wparam, LPARAM lparam)
 {
+    bool isMaximized = IsZoomed(flutter_window);
+    if(isMaximized)
+        return HTCLIENT;
     POINT pt = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
     ScreenToClient(window, &pt);
     RECT rc;
@@ -199,7 +202,7 @@ LRESULT handle_nccalcsize(HWND window, WPARAM wparam, LPARAM lparam)
     bool isMaximized = IsZoomed(window);
     if (isMaximized)
     {
-        int resizeMargin = getResizeMargin(window);
+        int resizeMargin = getResizeMargin(window)-1;
         params->rgrc[0].left += resizeMargin;
         params->rgrc[0].top += resizeMargin;
         params->rgrc[0].right -= resizeMargin;

--- a/windows/bitsdojo_window.cpp
+++ b/windows/bitsdojo_window.cpp
@@ -133,6 +133,10 @@ int getResizeMargin(HWND window)
     UINT currentDpi = GetDpiForWindow(window);
     int resizeBorder = GetSystemMetricsForDpi(SM_CXSIZEFRAME, currentDpi);
     int borderPadding = GetSystemMetricsForDpi(SM_CXPADDEDBORDER, currentDpi);
+    bool isMaximized = IsZoomed(window);
+    if (isMaximized) {
+        return borderPadding;
+    }
     return resizeBorder + borderPadding;
 }
 
@@ -202,7 +206,7 @@ LRESULT handle_nccalcsize(HWND window, WPARAM wparam, LPARAM lparam)
     bool isMaximized = IsZoomed(window);
     if (isMaximized)
     {
-        int resizeMargin = getResizeMargin(window)-1;
+        int resizeMargin = getResizeMargin(window);
         params->rgrc[0].left += resizeMargin;
         params->rgrc[0].top += resizeMargin;
         params->rgrc[0].right -= resizeMargin;


### PR DESCRIPTION
Fix for #14 
Previously when the window was maximized it was still hit testing borders for resizing and it was blocking buttons that are close to edges like the close button... 

now it ignores the resize border when the cursor is close to the edge and the window is maximized.
also to be able to hit the close button when the cursor is exactly at the top-right corner I added a `-1` to the window margin and now if you don't use the border widget in the flutter app's widget tree, you can hit the close button right in the corner.

so you can have a condition for the border widget (to not have it when the app is maximized) but I don't think it's necessary to be in this package.