### PR TITLE
[F] set static_framework to true would link the pod target statically…

### DIFF
--- a/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
+++ b/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
@@ -20,6 +20,6 @@ A new flutter plugin project.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 
-  s.static_framework = true
+  s.static_framework = false
   s.compiler_flags = '-fvisibility=hidden'
 end


### PR DESCRIPTION
Fixed the error occurs when build macos app with **release**:
```
#0      DynamicLibrary.lookup (dart:ffi-patch/ffi_dynamic_library_patch.dart:31)
#1      bitsdojoWindowAPI (package:bitsdojo_window_macos/src/native_api.dart:198)
#2      _publicAPI (package:bitsdojo_window_macos/src/native_api.dart)
#3      _setWindowCanBeShown (package:bitsdojo_window_macos/src/native_api.dart)
#4      setWindowCanBeShown (package:bitsdojo_window_macos/src/native_api.dart)
#5      BitsdojoWindowMacOS.doWhenWindowReady.<anonymous closure> (package:bitsdojo_window_macos/src/bitsdojo_window_macos_real.dart:14)
```
'Cause set static_framework to true would link the pod target statically to the parent target, which would not generate a bitsdojo_window_macos.framework, the framework should be dynamically loaded by dart ffi