### PR TITLE
Fix gtk library name

### DIFF
--- a/bitsdojo_window_linux/lib/src/gtk.dart
+++ b/bitsdojo_window_linux/lib/src/gtk.dart
@@ -1,7 +1,7 @@
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 
-final _libgtk = DynamicLibrary.open('libgtk-3.so');
+final _libgtk = DynamicLibrary.open('libgtk-3.so.0');
 
 final gtkWidgetGetParentWindow = _libgtk.lookupFunction<
     IntPtr Function(IntPtr widget),


### PR DESCRIPTION
On some distros libgtk-3.so isn't symlinked which results in a crash on startup