### PR TITLE
Implement RestoreWindowButton

### DIFF
--- a/bitsdojo_window/example/lib/main.dart
+++ b/bitsdojo_window/example/lib/main.dart
@@ -99,14 +99,34 @@ final closeButtonColors = WindowButtonColors(
     iconNormal: const Color(0xFF805306),
     iconMouseOver: Colors.white);
 
-class WindowButtons extends StatelessWidget {
+class WindowButtons extends StatefulWidget {
   const WindowButtons({Key? key}) : super(key: key);
+
+  @override
+  _WindowButtonsState createState() => _WindowButtonsState();
+}
+
+class _WindowButtonsState extends State<WindowButtons> {
+  void maximizeOrRestore() {
+    setState(() {
+      appWindow.maximizeOrRestore();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
         MinimizeWindowButton(colors: buttonColors),
-        MaximizeWindowButton(colors: buttonColors),
+        appWindow.isMaximized
+            ? RestoreWindowButton(
+                colors: buttonColors,
+                onPressed: maximizeOrRestore,
+              )
+            : MaximizeWindowButton(
+                colors: buttonColors,
+                onPressed: maximizeOrRestore,
+              ),
         CloseWindowButton(colors: closeButtonColors),
       ],
     );

--- a/bitsdojo_window/lib/src/widgets/window_button.dart
+++ b/bitsdojo_window/lib/src/widgets/window_button.dart
@@ -167,6 +167,21 @@ class MaximizeWindowButton extends WindowButton {
             onPressed: onPressed ?? () => appWindow.maximizeOrRestore());
 }
 
+class RestoreWindowButton extends WindowButton {
+  RestoreWindowButton(
+      {Key? key,
+      WindowButtonColors? colors,
+      VoidCallback? onPressed,
+      bool? animate})
+      : super(
+            key: key,
+            colors: colors,
+            animate: animate ?? false,
+            iconBuilder: (buttonContext) =>
+                RestoreIcon(color: buttonContext.iconColor),
+            onPressed: onPressed ?? () => appWindow.maximizeOrRestore());
+}
+
 final _defaultCloseButtonColors = WindowButtonColors(
     mouseOver: Color(0xFFD32F2F),
     mouseDown: Color(0xFFB71C1C),


### PR DESCRIPTION
Implement `RestoreWindowButton`

Now, on the example app, `RestoreWindowButton` is used if the window is maximized.

![small](https://user-images.githubusercontent.com/45696119/121378689-cc118e00-c919-11eb-8e48-9418b8f5d65b.png)
![maximized](https://user-images.githubusercontent.com/45696119/121378703-cddb5180-c919-11eb-9b0c-a8039753bde0.png)
