### PR TITLE
windows: portability: Support Win7 and early Win10.

### DIFF
--- a/bitsdojo_window_windows/lib/src/native_api.dart
+++ b/bitsdojo_window_windows/lib/src/native_api.dart
@@ -22,6 +22,12 @@ typedef IntPtr TGetAppWindow();
 typedef DGetAppWindow = int Function();
 final DGetAppWindow getAppWindow = _publicAPI.ref.getAppWindow.asFunction();
 
+// isDPIAware
+typedef Int8 TIsDPIAware();
+typedef DIsDPIAware = int Function();
+final DIsDPIAware _isDPIAware = _publicAPI.ref.isDPIAware.asFunction();
+bool isDPIAware() => _isDPIAware() != 0;
+
 // setWindowCanBeShown
 typedef Void TSetWindowCanBeShown(Int8 value);
 typedef DSetWindowCanBeShown = void Function(int value);
@@ -54,6 +60,7 @@ class BDWPublicAPI extends Struct {
   external Pointer<NativeFunction<TSetMaxSize>> setMaxSize;
   external Pointer<NativeFunction<TSetWindowCutOnMaximize>>
       setWindowCutOnMaximize;
+  external Pointer<NativeFunction<TIsDPIAware>> isDPIAware;
 }
 
 class BDWAPI extends Struct {

--- a/bitsdojo_window_windows/lib/src/window.dart
+++ b/bitsdojo_window_windows/lib/src/window.dart
@@ -36,6 +36,7 @@ Rect getScreenRectForWindow(int handle) {
 }
 
 class WinWindow extends WinDesktopWindow {
+  static final dpiAware = native.isDPIAware();
   int? handle;
   Size? _minSize;
   Size? _maxSize;
@@ -86,7 +87,9 @@ class WinWindow extends WinDesktopWindow {
 
   double systemMetric(int metric, {int dpiToUse = 0}) {
     final windowDpi = dpiToUse != 0 ? dpiToUse : this.dpi;
-    double result = GetSystemMetricsForDpi(metric, windowDpi).toDouble();
+    double result = dpiAware
+      ? GetSystemMetricsForDpi(metric, windowDpi).toDouble()
+      : GetSystemMetrics(metric).toDouble();
     return result;
   }
 
@@ -95,7 +98,7 @@ class WinWindow extends WinDesktopWindow {
   }
 
   int get dpi {
-    if (!isValidHandle(handle, "get dpi")) return 96;
+    if (!dpiAware || !isValidHandle(handle, "get dpi")) return 96;
     return GetDpiForWindow(handle!);
   }
 

--- a/bitsdojo_window_windows/windows/bitsdojo_window.h
+++ b/bitsdojo_window_windows/windows/bitsdojo_window.h
@@ -5,7 +5,7 @@
 namespace bitsdojo_window {
     typedef bool (*TIsBitsdojoWindowLoaded)();
     bool isBitsdojoWindowLoaded();
-    
+
     typedef void (*TSetWindowCanBeShown)(bool);
     void setWindowCanBeShown(bool value);
 
@@ -23,5 +23,8 @@ namespace bitsdojo_window {
 
     typedef void (*TSetWindowCutOnMaximize)(int);
     void setWindowCutOnMaximize(int value);
+
+    typedef bool (*TIsDPIAware)();
+    bool isDPIAware();
 }
 #endif

--- a/bitsdojo_window_windows/windows/bitsdojo_window_api.cpp
+++ b/bitsdojo_window_windows/windows/bitsdojo_window_api.cpp
@@ -4,7 +4,7 @@
 
 namespace bitsdojo_window {
     BDWPrivateAPI privateAPI = {
-        dragAppWindow
+        dragAppWindow,
     };
 
     BDWPublicAPI publicAPI = {
@@ -13,7 +13,8 @@ namespace bitsdojo_window {
         setWindowCanBeShown,
         setMinSize,
         setMaxSize,
-        setWindowCutOnMaximize
+        setWindowCutOnMaximize,
+        isDPIAware,
     };
 }
 

--- a/bitsdojo_window_windows/windows/bitsdojo_window_api.h
+++ b/bitsdojo_window_windows/windows/bitsdojo_window_api.h
@@ -7,7 +7,7 @@
 namespace bitsdojo_window {
 
     typedef struct  _BDWPrivateAPI{
-        TDragAppWindow dragAppWindow;        
+        TDragAppWindow dragAppWindow;
     } BDWPrivateAPI;
 
     typedef struct _BDWPublicAPI {
@@ -17,6 +17,7 @@ namespace bitsdojo_window {
         TSetMinSize setMinSize;
         TSetMaxSize setMaxSize;
         TSetWindowCutOnMaximize setWindowCutOnMaximize;
+        TIsDPIAware isDPIAware;
     } BDWPublicAPI;
 
 }


### PR DESCRIPTION
This dynamically loads the `GetDpiForWindow` and `GetSystemMetricsForDpi` to support running on Win7.

Also, some older Win10 machines were crashing in the NCCALCSIZE handler as they were (initially) passing a null LPARAM.
