### PR TITLE
Allow custom sized title bars

### DIFF
--- a/bitsdojo_window/lib/src/widgets/window_button.dart
+++ b/bitsdojo_window/lib/src/widgets/window_button.dart
@@ -127,8 +127,7 @@ class WindowButton extends StatelessWidget {
         var button = (this.builder != null)
             ? this.builder!(buttonContext, icon)
             : iconWithPadding;
-        return SizedBox(
-            width: buttonSize.width, height: buttonSize.height, child: button);
+        return SizedBox(width: buttonSize.width, child: button);
       },
       onPressed: () {
         if (this.onPressed != null) this.onPressed!();

--- a/bitsdojo_window/lib/src/widgets/window_caption.dart
+++ b/bitsdojo_window/lib/src/widgets/window_caption.dart
@@ -36,13 +36,15 @@ class MoveWindow extends StatelessWidget {
 
 class WindowTitleBarBox extends StatelessWidget {
   final Widget? child;
-  WindowTitleBarBox({Key? key, this.child}) : super(key: key);
+  final double? height;
+  WindowTitleBarBox({Key? key, this.child, this.height}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     if (kIsWeb) {
       return Container();
     }
     final titlebarHeight = appWindow.titleBarHeight;
-    return SizedBox(height: titlebarHeight, child: this.child ?? Container());
+    return SizedBox(
+        height: height ?? titlebarHeight, child: this.child ?? Container());
   }
 }


### PR DESCRIPTION
Many applications have an increased title bar height to make room for functional components.

These two small changes allow this functionality with no affect to existing users.