### PR TITLE
Adds a linker flag to link against C++ on macOS

### DIFF
--- a/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
+++ b/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
@@ -25,6 +25,7 @@ A new flutter plugin project.
   s.library = 'c++'
   s.xcconfig = {
        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
-       'CLANG_CXX_LIBRARY' => 'libc++'
+       'CLANG_CXX_LIBRARY' => 'libc++',
+       'OTHER_LDCONFIG' => '-lobjc -lc++'
   }
 end

--- a/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
+++ b/bitsdojo_window_macos/macos/bitsdojo_window_macos.podspec
@@ -22,4 +22,9 @@ A new flutter plugin project.
 
   s.static_framework = false
   s.compiler_flags = '-fvisibility=hidden'
+  s.library = 'c++'
+  s.xcconfig = {
+       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
+       'CLANG_CXX_LIBRARY' => 'libc++'
+  }
 end


### PR DESCRIPTION
bitsdojo_window plugin works fine on Intel mac machines now. However, when using the plug-in on Apple Silicon CPUs like M1, the linker throws an error and says some C++ symbols are missing. The pull request fixes the issue by updating the Podfile.