### PR TITLE
fix: macos toolbar button not hidden

### DIFF
--- a/bitsdojo_window_macos/macos/Classes/BitsdojoWindow.swift
+++ b/bitsdojo_window_macos/macos/Classes/BitsdojoWindow.swift
@@ -38,6 +38,10 @@ open class BitsdojoWindow: NSWindow {
         self.titleVisibility = .hidden
         self.isOpaque = false
         self.isMovable = false
+        // hidden toolbar button
+        self.standardWindowButton(.closeButton)?.isHidden = true
+        self.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        self.standardWindowButton(.zoomButton)?.isHidden = true
     }
     super.order(place, relativeTo: otherWin)
     let windowCanBeShown: Bool = bdwPrivateAPI.windowCanBeShown();


### PR DESCRIPTION
before:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/17287671/174794805-aac13e94-98d7-415a-b473-9c826cb55579.png">

after:
![image](https://user-images.githubusercontent.com/17287671/174794914-0bbe096a-2428-40c8-95b8-4d9cb4ea840b.png)

hidden these button