### PR TITLE
Allow use of win32 4.x

### DIFF
--- a/bitsdojo_window_windows/pubspec.yaml
+++ b/bitsdojo_window_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   bitsdojo_window_platform_interface: ^0.1.2
     #path: ../bitsdojo_window_platform_interface
-  win32: ^3.0.0
+  win32: ">=3.0.0 <5.0.0"
   ffi: ^2.0.0
 
 


### PR DESCRIPTION
Expands the allowed range of win32 plugin as this plugin uses nothing that was affected by the breaking changes.