### PR TITLE
remove usage of deprecated `withOpacity` function

### DIFF
--- a/bitsdojo_window/lib/src/widgets/window_button.dart
+++ b/bitsdojo_window/lib/src/widgets/window_button.dart
@@ -113,7 +113,7 @@ class WindowButton extends StatelessWidget {
             (appWindow.titleBarHeight - borderSize) / 3 - (borderSize / 2);
         // Used when buttonContext.backgroundColor is null, allowing the AnimatedContainer to fade-out smoothly.
         var fadeOutColor =
-            getBackgroundColor(MouseState()..isMouseOver = true).withOpacity(0);
+            getBackgroundColor(MouseState()..isMouseOver = true).withAlpha(0);
         var padding = this.padding ?? EdgeInsets.all(defaultPadding);
         var animationMs =
             mouseState.isMouseOver ? (animate ? 100 : 0) : (animate ? 200 : 0);


### PR DESCRIPTION
From the Flutter migration guide: https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity

the usage of the `withOpacity` function will be removed in favor of floating point