### PR TITLE
Fix/linux init race

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `bitsdojo_window/`: Core Flutter plugin package (widgets, API surface).
+- `bitsdojo_window_platform_interface/`: Shared platform interface for the federated plugin.
+- `bitsdojo_window_macos/`, `bitsdojo_window_windows/`, `bitsdojo_window_linux/`: Platform implementation packages (Swift/Obj‑C++, C++/Win32, GTK) and plugin wiring.
+- `bitsdojo_window/*/example/`: Example app to validate behavior on each platform.
+- `resources/`: Images/assets for docs.
+
+## Build, Test, and Development Commands
+- Install deps (per package): `cd <package> && dart pub get`
+- Analyze: `dart analyze .` (run in each Dart package)
+- Format: `dart format .` (2‑space indent; use trailing commas)
+- Run example for manual testing:
+  - macOS: `cd bitsdojo_window/example && flutter run -d macos`
+  - Windows: `cd bitsdojo_window/example && flutter run -d windows`
+  - Linux: `cd bitsdojo_window/example && flutter run -d linux`
+
+## Coding Style & Naming Conventions
+- Dart: 2 spaces; files `snake_case.dart`; classes `UpperCamelCase`; members `lowerCamelCase`.
+- Prefer `const`; keep constructors and args trailing‑comma friendly for stable formatting.
+- Platform sources: headers `.h`, impl `.mm`/`.mm` (macOS) or `.cpp` (Windows/Linux); filenames `snake_case`.
+
+## Testing Guidelines
+- No unit tests currently. Validate via the example app on each target OS.
+- Manual checks: draggable regions, caption buttons, resize/hover states, theme transitions.
+- When filing issues, include OS + Flutter versions (`flutter doctor -v`).
+
+## Commit & Pull Request Guidelines
+- Commits: short, imperative subject with optional scope, e.g. `windows: fix maximize`, `macos: avoid titlebar flicker`, `core: null‑safety cleanup`.
+- PRs should include:
+  - Summary and rationale; linked issues.
+  - Platforms tested + steps; screenshots/GIFs for UI changes.
+  - Notes on breaking changes or migrations.
+
+## Publishing (pub.dev) Checklist
+- Bump versions in each published `pubspec.yaml` and update corresponding `CHANGELOG.md`.
+- Dry run per package: `dart pub publish --dry-run`
+- Publish order (typical): `platform_interface` → platform packages → `bitsdojo_window`.
+- Tag release(s) after publish; verify package pages render README and assets.

--- a/bitsdojo_window/lib/src/widgets/window_button.dart
+++ b/bitsdojo_window/lib/src/widgets/window_button.dart
@@ -113,7 +113,7 @@ class WindowButton extends StatelessWidget {
             (appWindow.titleBarHeight - borderSize) / 3 - (borderSize / 2);
         // Used when buttonContext.backgroundColor is null, allowing the AnimatedContainer to fade-out smoothly.
         var fadeOutColor =
-            getBackgroundColor(MouseState()..isMouseOver = true).withOpacity(0);
+            getBackgroundColor(MouseState()..isMouseOver = true).withAlpha(0);
         var padding = this.padding ?? EdgeInsets.all(defaultPadding);
         var animationMs =
             mouseState.isMouseOver ? (animate ? 100 : 0) : (animate ? 200 : 0);

--- a/bitsdojo_window_linux/lib/src/app_window.dart
+++ b/bitsdojo_window_linux/lib/src/app_window.dart
@@ -13,8 +13,13 @@ class BitsDojoNotInitializedException implements Exception {
 
 class GtkAppWindow extends GtkWindow {
   GtkAppWindow._() {
-    super.handle = native.getAppWindowHandle();
-    assert(handle != null, "Could not get Flutter window");
+    final h = native.getAppWindowHandle();
+    if (h != 0) {
+      super.handle = h;
+    } else {
+      // Defer initialization; handle will be set once ready.
+      super.handle = null;
+    }
   }
 
   static final GtkAppWindow _instance = GtkAppWindow._();

--- a/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
+++ b/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
@@ -15,6 +15,15 @@ class BitsdojoWindowLinux extends BitsdojoWindowPlatform {
     _ambiguate(WidgetsBinding.instance)!
         .waitUntilFirstFrameRasterized
         .then((value) {
+      // Attempt to ensure the native window handle is ready once the first
+      // frame is rasterized. If still not ready, caller ops will no-op safely.
+      final app = GtkAppWindow();
+      if (app.handle == null || app.handle == 0) {
+        final h = native.getAppWindowHandle();
+        if (h != 0) {
+          app.handle = h;
+        }
+      }
       isInsideDoWhenWindowReady = true;
       callback();
       isInsideDoWhenWindowReady = false;

--- a/bitsdojo_window_linux/lib/src/window.dart
+++ b/bitsdojo_window_linux/lib/src/window.dart
@@ -10,7 +10,7 @@ import 'package:bitsdojo_window_platform_interface/bitsdojo_window_platform_inte
 var isInsideDoWhenWindowReady = false;
 
 bool isValidHandle(int? handle, String operation) {
-  if (handle == null) {
+  if (handle == null || handle == 0) {
     print("Could not $operation - handle is null");
     return false;
   }

--- a/bitsdojo_window_windows/windows/bitsdojo_window.cpp
+++ b/bitsdojo_window_windows/windows/bitsdojo_window.cpp
@@ -229,10 +229,21 @@ namespace bitsdojo_window {
         return monitorInfo.rcWork;
     }
 
+    RECT getWorkingScreenRectForRect(const RECT& rcWnd) {
+      MONITORINFO monitorInfo = {};
+      monitorInfo.cbSize = DWORD(sizeof(MONITORINFO));
+      auto monitor = MonitorFromRect(&rcWnd, MONITOR_DEFAULTTONEAREST);
+      GetMonitorInfoW(monitor, static_cast<LPMONITORINFO>(&monitorInfo));
+      return monitorInfo.rcWork;
+    }
+    RECT getWorkingScreenRectForWindowPos(WINDOWPOS* winPos) {
+      RECT rcWnd = { winPos->x, winPos->y, winPos->x + winPos->cx, winPos->y + winPos->cy };
+      return getWorkingScreenRectForRect(rcWnd);
+    }
     void adjustPositionOnRestoreByMove(HWND window, WINDOWPOS* winPos) {
         if (restore_by_moving == FALSE) return;
 
-        auto screenRect = getWorkingScreenRectForWindow(window);
+        auto screenRect = getWorkingScreenRectForWindowPos(winPos);
         
         if (winPos->y < screenRect.top) {
             winPos->y = screenRect.top;
@@ -240,7 +251,7 @@ namespace bitsdojo_window {
     }
 
     void adjustMaximizedSize(HWND window, WINDOWPOS* winPos) {
-        auto screenRect = getWorkingScreenRectForWindow(window);
+        auto screenRect = getWorkingScreenRectForWindowPos(winPos);
         if ((winPos->x < screenRect.left) &&
             (winPos->y < screenRect.top) &&
             (winPos->cx > (screenRect.right - screenRect.left))
@@ -253,7 +264,7 @@ namespace bitsdojo_window {
     }
 
     void adjustMaximizedRects(HWND window, NCCALCSIZE_PARAMS* params) {
-        auto screenRect = getWorkingScreenRectForWindow(window);
+        auto screenRect = getWorkingScreenRectForRect(params->rgrc[0]);
         for (int i = 0; i < 3; i++) {
             if ((params->rgrc[i].left < screenRect.left) &&
                 (params->rgrc[i].top < screenRect.top) &&


### PR DESCRIPTION
- Compare URL: https://github.com/kingdomseed/desktop_title_bar_controls/compare/master...fix/linux-init-race?expand=1
- Base: master
- Head: fix/linux-init-race

PR Title
Linux: harden startup against race conditions (getAppWindowHandle + handle readiness)

PR Body
Summary

- Avoids release-only startup segfaults on Linux by turning an early-call race into a safe “not ready yet” state.


- Native (Linux):
    - Guard plugin pointer with std::atomic and return nullptr if not ready.
    - Cache GtkWindow* on “realize”; reuse cached handle; log once when plugin/view not ready.
- Dart (Linux):
    - Treat handle == 0 as invalid; drop assert in constructor and defer init.
    - After first frame (doWhenWindowReady), attempt to set the handle once if available.

Rationale

- Issue #230 reports a segfault when getAppWindowHandle() races with plugin registration/view realization. This makes calls deterministic and crash-free without blocking GTK.

Testing

- Repro app calling appWindow.show() early vs inside doWhenWindowReady.
- Release builds on X11 and Wayland; verify no segfault and single, non-spammy warning on early access.
- Confirm Windows/macOS unaffected.

Notes for Reviewers

- No blocking or busy-waiting; retries are async/one-shot.
- Consider a follow-up to export isAppWindowReady() and clear the cache on destroy/unrealize (hot restart hardening).

Checklist

- [ ] Verify Linux example runs without segfault when calling early and inside doWhenWindowReady.
- [ ] Validate on X11 and Wayland (Ubuntu/Pop!_OS/Fedora).
- [ ] Check native logs show at most one warning when called too early.
- [ ] Confirm no regressions on Windows/macOS paths.
- [ ] Optional: ASAN build shows no null deref.

Breaking Changes

- None. Linux only; behavior is more robust for early calls.

Files Touched

- bitsdojo_window_linux/linux/bitsdojo_window_plugin.cpp
- bitsdojo_window_linux/lib/src/app_window.dart
- bitsdojo_window_linux/lib/src/window.dart
- bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart